### PR TITLE
Allow backwards sevens

### DIFF
--- a/isseven/checkers.py
+++ b/isseven/checkers.py
@@ -34,8 +34,9 @@ def is_the_word_seven(possible_seven: str) -> IsSevenResult:
     tidied_possible_seven = possible_seven.strip().lower()
     if tidied_possible_seven in sevens:
         return yep(sevens[tidied_possible_seven])
-    if tidied_possible_seven[::-1] in sevens:
-        return yep(sevens[tidied_possible_seven] + " backwards")
+    reversed_word = tidied_possible_seven[::-1]
+    if reversed_word in sevens:
+        return yep(sevens[reversed_word] + " backwards")
     return nope("Not the word seven")
 
 

--- a/isseven/checkers.py
+++ b/isseven/checkers.py
@@ -35,7 +35,7 @@ def is_the_word_seven(possible_seven: str) -> IsSevenResult:
     if tidied_possible_seven in sevens:
         return yep(sevens[tidied_possible_seven])
     if tidied_possible_seven[::-1] in sevens:
-        return yep(sevens[tidied_possible_sven] + " backwards")
+        return yep(sevens[tidied_possible_seven] + " backwards")
     return nope("Not the word seven")
 
 

--- a/isseven/checkers.py
+++ b/isseven/checkers.py
@@ -34,6 +34,8 @@ def is_the_word_seven(possible_seven: str) -> IsSevenResult:
     tidied_possible_seven = possible_seven.strip().lower()
     if tidied_possible_seven in sevens:
         return yep(sevens[tidied_possible_seven])
+    if tidied_possible_seven[::-1] in sevens:
+        return yep(sevens[tidied_possible_sven] + " backwards")
     return nope("Not the word seven")
 
 


### PR DESCRIPTION
Not all sevens arrive in the right order so we must ensure we also lock for "neves", "nebeis", etc.